### PR TITLE
Try bringing syntax hightlighting back

### DIFF
--- a/docs/.vuepress/components/Code.vue
+++ b/docs/.vuepress/components/Code.vue
@@ -1,0 +1,88 @@
+<template>
+    <div>
+        <h2>JavaScript</h2>
+        <Editor :content="js" type="plain" :editor-props="editorProps"/>
+        <h2>CSS</h2>
+        <Editor :content="css" type="plain" :editor-props="editorProps"/>
+    </div>
+</template>
+
+<script>
+import javascript from 'highlight.js/lib/languages/javascript'
+import css from 'highlight.js/lib/languages/css'
+import 'highlight.js/styles/github.css';
+
+const languages = { javascript, css }
+export default {
+    name: 'Code',
+    data() {
+        return {
+            css: `body { color: red; }`,
+            js: `const example = 'Hello world'
+console.debug(example)`,
+            editorProps: {
+                languages: languages
+            },
+        }
+    }
+}
+</script>
+<style lang="scss">
+
+pre {
+  &::before {
+    content: attr(data-language);
+    text-transform: uppercase;
+    display: block;
+    text-align: right;
+    font-weight: bold;
+    font-size: 0.6rem;
+  }
+  code {
+    .hljs-comment,
+    .hljs-quote {
+      color: #999999;
+    }
+    .hljs-variable,
+    .hljs-template-variable,
+    .hljs-attribute,
+    .hljs-tag,
+    .hljs-name,
+    .hljs-regexp,
+    .hljs-link,
+    .hljs-name,
+    .hljs-selector-id,
+    .hljs-selector-class {
+      color: #f2777a;
+    }
+    .hljs-number,
+    .hljs-meta,
+    .hljs-built_in,
+    .hljs-builtin-name,
+    .hljs-literal,
+    .hljs-type,
+    .hljs-params {
+      color: #f99157;
+    }
+    .hljs-string,
+    .hljs-symbol,
+    .hljs-bullet {
+      color: #99cc99;
+    }
+    .hljs-title,
+    .hljs-section {
+      color: #ffcc66;
+    }
+    .hljs-keyword,
+    .hljs-selector-tag {
+      color: #6699cc;
+    }
+    .hljs-emphasis {
+      font-style: italic;
+    }
+    .hljs-strong {
+      font-weight: 700;
+    }
+  }
+}
+</style>

--- a/docs/plain.md
+++ b/docs/plain.md
@@ -1,3 +1,5 @@
 ## Plain text
 
 <PlainText />
+
+<Code />

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"core-js": "^3.6.5",
 		"entities": "^2.0.2",
 		"escape-html": "^1.0.3",
-		"highlight.js": "^9.18.0",
+		"highlight.js": "9.16.2",
 		"markdown-it": "^11.0.0",
 		"markdown-it-task-lists": "^2.1.1",
 		"prosemirror-collab": "^1.2.2",

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -85,12 +85,13 @@ export default {
 		},
 	},
 	mounted() {
+		const passedProps = this.editorProps
 		const props = {
 			editorClass: this.type === EDITOR_TYPES.MARKDOWN ? MarkdownEditor : TiptapEditor,
 			enableRichEditing: this.type !== EDITOR_TYPES.PLAIN,
-			languages: undefined,
+			languages: this.editorProps.languages ? {...this.editorProps.languages} : undefined,
 			content: this.type !== EDITOR_TYPES.PLAIN ? this.content : '<code><pre>' + this.content + '</pre></code>',
-			...this.editorProps,
+			...this.passedProps,
 			onUpdate: (state) => {
 				switch (this.type) {
 				case EDITOR_TYPES.MARKDOWN:

--- a/src/editor.js
+++ b/src/editor.js
@@ -104,10 +104,16 @@ const createEditor = ({ editorClass, content, onInit, onUpdate, extensions, enab
 		richEditingExtensions = [
 			new PlainTextDocument(),
 			new Text(),
-			new CodeBlockHighlight({
-				...languages,
-			}),
 		]
+		console.log(languages)
+
+		if (languages) {
+			richEditingExtensions.push(new CodeBlockHighlight({
+				languages: languages,
+			}))
+		} else {
+			richEditingExtensions.push(new CodeBlockHighlight())
+		}
 	}
 	extensions = extensions || []
 	const params = {

--- a/src/styles/prosemirror.scss
+++ b/src/styles/prosemirror.scss
@@ -7,7 +7,6 @@ div.ProseMirror {
 	white-space: pre-wrap;
 	-webkit-font-variant-ligatures: none;
 	font-variant-ligatures: none;
-	padding: 4px 8px 200px 14px;
 	line-height: 150%;
 	font-size: 14px;
 	outline: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5057,11 +5057,7 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
 
-highlight.js@^9.18.0:
-  version "9.18.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
-
-highlight.js@~9.16.0:
+highlight.js@9.16.2, highlight.js@~9.16.0:
   version "9.16.2"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.16.2.tgz#68368d039ffe1c6211bcc07e483daf95de3e403e"
 


### PR DESCRIPTION
Solves remaining part of #65 

- [x] Allow to inject highlight.js languages
- [ ] Check if we can use highlight > 3.16.2 together with the tiptap CodeBlockHighlight plugin
- [ ] Enhance docs